### PR TITLE
Adding a Docker image containing every single setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ cd ../..
 pip install -r requirements.txt
 ```
 
+- Alternatively, use the [Docker image](https://hub.docker.com/layers/trngon11/llama-x-finetuning-ai/latest/images/sha256-42e570ec95026141f12aef802e36801dd8d9eadc8351f96657ac8621c6dcfb12?context=repo) with everything already set up and ready for training, ideal for quickly deploying on GPU rental services:
+```bash
+docker pull trngon11/llama-x-finetuning-ai:latest
+```
+
 - Training data example (e.g., [Stanford Alpaca](https://github.com/tatsu-lab/stanford_alpaca/blob/main/alpaca_data.json)):
 ```bash
 Llama-X/src/data/alpaca_data.json


### PR DESCRIPTION
I have created a Docker image to streamline the setup process for LLaMA-X model training on GPU rental services like vast.ai. Currently, setting up the required dependencies such as CUDA and PyTorch is a time-consuming and repetitive chore, hindering the efficiency of researchers and developers. With this Docker image, we can eliminate the need to repeat these steps every single time, making the setup process quick and hassle-free.

This Docker image encapsulates the necessary software stack, including CUDA, PyTorch, and other dependencies, allowing users to spin up a ready-to-use environment for LLaMA-X model training in minutes. 

The image itself is based on Nvidia's official CUDA 11.3 docker image, with conda installing pytorch and all dependencies. I've tested it on a couple different vast.ai GPU instances and all worked. 